### PR TITLE
allow momentjs >= 2.5.0

### DIFF
--- a/bootstrap3-datetimepicker-rails.gemspec
+++ b/bootstrap3-datetimepicker-rails.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'
 
-  spec.add_runtime_dependency 'momentjs-rails', '~> 2.5.0'
+  spec.add_runtime_dependency 'momentjs-rails', '>= 2.5.0'
 end


### PR DESCRIPTION
As stated by bootstrap3-datetimepicker 's bower file (https://github.com/Eonasdan/bootstrap-datetimepicker/blob/master/bower.json#L11), we don't have to force moment js version `=2.5.0`, but `>=2.5.0`. Using momentjs is working fine for me, fixes #7
