### PR TITLE
Update readme to include bootstrap-sprockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Add the following to your stylesheet file:
 
 If you are using SCSS, modify your `application.css.scss`
 ```scss
+@import "bootstrap-sprockets";
 @import 'bootstrap';
 @import 'bootstrap-datetimepicker';
 ```


### PR DESCRIPTION
bootstrap-sprockets needs to be included so that functions are there to have the correct asset path.
