### PR TITLE
Fix: Can't use minDate with Stepping

### DIFF
--- a/vendor/assets/javascripts/bootstrap-datetimepicker.js
+++ b/vendor/assets/javascripts/bootstrap-datetimepicker.js
@@ -862,6 +862,10 @@
 
                 if (options.stepping !== 1) {
                     targetMoment.minutes((Math.round(targetMoment.minutes() / options.stepping) * options.stepping)).seconds(0);
+                 
+                    while (options.minDate && targetMoment.isBefore(options.minDate)) {
+   +                        targetMoment.add(options.stepping, 'minutes');
+   +                    }
                 }
 
                 if (isValid(targetMoment)) {


### PR DESCRIPTION
Fix issues where minDate does not work with stepping. source: https://github.com/Eonasdan/bootstrap-datetimepicker/issues/1065 

Has been solved for others but not yet for rails gem.