### PR TITLE
Require Moment.js version of at least 2.9.0

### DIFF
--- a/bootstrap3-datetimepicker-rails.gemspec
+++ b/bootstrap3-datetimepicker-rails.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'
 
-  spec.add_runtime_dependency 'momentjs-rails', '>= 2.8.1'
+  spec.add_runtime_dependency 'momentjs-rails', '>= 2.9.0'
 end


### PR DESCRIPTION
Recent versions of `bootstrap-datetimepicker` [use the `moment.isDate()` function](https://github.com/Eonasdan/bootstrap-datetimepicker/blob/25c11d79e614bc6463a87c3dd9cbf8280422e006/src/js/bootstrap-datetimepicker.js#L145), which wasn't exposed in Moment.js until version 2.9.0 ([changelog](https://gist.github.com/ichernev/0c9a9b49951111a27ce7)). Requiring version 2.9.0 of `momentjs-rails` in the `gemspec` will make developers that are upgrading to a recent version of `bootstrap3-datetimepicker-rails` aware of this dependency.

A similar change was already made to the `README` in 84e78ecf17588f0f1e381cb758e30b2cdd0adc48.